### PR TITLE
[ReLayout] Improve performance in binding overhead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,29 @@ stubtest` and `npm run stubtestbindingsperf`.
 
 ```sh
 sudo instruments -v -t 'Time Profiler'  -D ~/Desktop/yourTrace.trace _build/test/test
+# To open in Instruments, need to restore perms.
+sudo chown -R you:staff ~/Desktop/yourTrace.trace
+# Now open Instruments.app and open the trace.
 ```
+
+Then open Instruments.app (GUI), and open file test.trace.
+- Enable "High Frequency" and disable "Hide System Libraries" in the GUI to see
+  all the content.
+- Click on the gear, then click "Invert Call Tree" and "Top Functions".
+- Right click on the table view header and enable `Self # Samples`  and `#
+  Samples`. It's important to open these to get the full picture in the
+  abscense of perfect profiling symbols.
+- Click on "Self #Samples" to sort so that the highest numbers are first.
+
+
+The result is that you have the bottlenecks at the top. When you drill down in
+the tree, it tells you who's calling that bottleneck.  Many of the symbols are
+still obfuscated (4.03 improves that).  Open up all the .s files that ocamlopt
+dumped so that when you see obfuscated symbols in the Instruments GUI, you can
+search for that symbol in all the .s files you have open. Double click on the
+actual symbol in instruments and it will show you what the assembly looks like
+and you can match it to the symbol you have open in your editor. There may be
+multiple .L123 across all the files so you can cross reference Instruments
+(double click) which shows you the assembly.  4.03 is said to greatly improve
+the source locations when profiling so it tells you the function names instead
+of assembly locations more often than not.

--- a/stub/Yoga.c
+++ b/stub/Yoga.c
@@ -47,11 +47,9 @@ char* itoa(uintnat val, int base){
 static bool inCall = false;
 
 value re_callback (value closure, value arg1, const char * tag) {
-    value arg[1];
-    arg[0] = arg1;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONSTART", tag); */
     inCall = true;
-    value res = caml_callbackN_exn(closure, 1, arg);
+    value res = caml_callback(closure, arg1);
     inCall = false;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONEND", tag); */
     if (Is_exception_result(res)) {
@@ -65,12 +63,9 @@ value re_callback (value closure, value arg1, const char * tag) {
 }
 
 value re_callback2 (value closure, value arg1, value arg2, const char * tag) {
-    value arg[2];
-    arg[0] = arg1;
-    arg[1] = arg2;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONSTART", tag); */
     inCall = true;
-    value res = caml_callbackN_exn(closure, 2, arg);
+    value res = caml_callback2(closure, arg1, arg2);
     inCall = false;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONSEND", tag); */
     if (Is_exception_result(res)) {
@@ -85,13 +80,9 @@ value re_callback2 (value closure, value arg1, value arg2, const char * tag) {
 
 value re_callback3 (value closure, value arg1, value arg2,
                     value arg3, const char * tag) {
-    value arg[3];
-    arg[0] = arg1;
-    arg[1] = arg2;
-    arg[2] = arg3;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONSTART", tag); */
     inCall = true;
-    value res = caml_callbackN_exn(closure, 3, arg);
+    value res = caml_callback3(closure, arg1, arg2, arg3);
     inCall = false;
     /* __android_log_write(ANDROID_LOG_ERROR, "REASONEND", tag); */
     if (Is_exception_result(res)) {


### PR DESCRIPTION
Summary: using the dedicated caml_callback/2/3 reduces total overhead by
about 13% of total running time!

Test Plan:

Reviewers:

CC: