### PR TITLE
Version: Bump both esy.json and package.json versions to 1.2.2

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -1,6 +1,6 @@
 {
   "name": "flex",
-  "version": "1.1.1",
+  "version": "1.2.2",
   "description": "Implementation CSS layout using pure Reason - powered by css-layout project",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Implementation CSS layout using pure Reason - powered by css-layout project",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After testing #21 , I saw that the version was confusingly being reported as `1.1.1` by `esy ls-builds -T` - even though I had the up-to-date bits.

I saw that I missed updating the version in `esy.json`, so esy was reporting that version as opposed to the `package.json`. I wonder if there is some way we could warn about this situation in the future?

Sorry about the churn here @jordwalke ! 

FYI, I already published this `1.2.2` version so that no one would hit a confusing version number situation with `esy`.