### PR TITLE
fix(build): Loosen version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "dependencies": {
-    "ocaml": ">=4.6.1 <= 4.10.0",
+    "ocaml": ">=4.6.1",
     "@opam/dune": "^2.0.0",
     "@esy-ocaml/reason": "^3.0.0"
   },


### PR DESCRIPTION
`flex` won't build with later versions of OCaml, like `4.10.1002`, ie:

```
Conflicting constraints:
  Oni2 -> ocaml@=4.10.1002
  Oni2 -> revery -> flex -> ocaml@>=4.6.1 <=4.10.0
```

This just loosens up the version constraint - I believe it should be OK to include newer OCaml versions